### PR TITLE
Velocity field

### DIFF
--- a/include/body.hpp
+++ b/include/body.hpp
@@ -224,7 +224,6 @@ class SphericalBody : public Body {
     Eigen::MatrixXd A_;                         ///< Matrix representation of body for solver
     Eigen::PartialPivLU<Eigen::MatrixXd> A_LU_; ///< LU decomposition of A_ for preconditioner
 
-    /// Return reference to body COM position
     void update_RHS(MatrixRef &v_on_body) override;
     void update_cache_variables(double eta) override;
     void update_preconditioner(double eta) override;
@@ -237,7 +236,7 @@ class SphericalBody : public Body {
     Eigen::VectorXd apply_preconditioner(VectorRef &x) const override;
 
     Eigen::Vector3d get_position() const override { return position_; }
-    void move(const Eigen::Vector3d &new_pos, const Eigen::Quaterniond &new_orientation);
+    void place(const Eigen::Vector3d &new_pos, const Eigen::Quaterniond &new_orientation);
     void update_K_matrix();
     void update_singularity_subtraction_vecs(double eta);
 

--- a/include/body.hpp
+++ b/include/body.hpp
@@ -22,6 +22,7 @@ class Body {
     Eigen::MatrixXd node_normals_;       ///< [ 3 x n_nodes ] node normals in lab frame
     Eigen::MatrixXd node_normals_ref_;   ///< [ 3 x n_nodes ] node normals in reference 'body' frame
     Eigen::VectorXd node_weights_;       ///< [ n_nodes ] far field quadrature weights for nodes
+    Eigen::VectorXd solution_vec_;       ///< [ 3 * n_nodes + <body_specific> ] strength of interaction on nodes
 
     /// [ 3 x n_nucleation_sites ] nucleation site positions in reference 'body' frame
     Eigen::MatrixXd nucleation_sites_ref_;
@@ -246,7 +247,7 @@ class SphericalBody : public Body {
     bool check_collision(const DeformableBody &body, double threshold) const override;
 
     /// @brief Serialize body automatically with msgpack macros
-    MSGPACK_DEFINE_MAP(position_, orientation_);
+    MSGPACK_DEFINE_MAP(position_, orientation_, solution_vec_);
 };
 
 /// @brief Spherical Body...
@@ -278,7 +279,7 @@ class DeformableBody : public Body {
     bool check_collision(const SphericalBody &body, double threshold) const override;
     bool check_collision(const DeformableBody &body, double threshold) const override;
 
-    MSGPACK_DEFINE_MAP(node_positions_, node_normals_);
+    MSGPACK_DEFINE_MAP(node_positions_, node_normals_, solution_vec_);
 };
 
 #endif

--- a/include/fiber.hpp
+++ b/include/fiber.hpp
@@ -55,6 +55,7 @@ class Fiber {
     /// Boundary condition pair for plus end of fiber
     std::pair<BC, BC> bc_plus_ = {BC::Force, BC::Torque};
 
+    Eigen::VectorXd tension_; ///< [ n_nodes ] vector representing local tension on fiber nodes
     Eigen::MatrixXd x_;     ///< [ 3 x n_nodes_ ] matrix representing coordinates of fiber nodes
     Eigen::MatrixXd xs_;    ///< [ 3 x n_nodes_ ] matrix representing first derivative of fiber nodes
     Eigen::MatrixXd xss_;   ///< [ 3 x n_nodes_ ] matrix representing second derivative of fiber nodes
@@ -140,10 +141,10 @@ class Fiber {
     bool is_minus_clamped() { return minus_clamped_ || attached_to_body(); };
 #ifndef SKELLY_DEBUG
     MSGPACK_DEFINE_MAP(n_nodes_, length_, length_prev_, bending_rigidity_, penalty_param_, force_scale_, beta_tstep_,
-                       epsilon_, binding_site_, x_);
+                       epsilon_, binding_site_, tension_, x_);
 #else
     MSGPACK_DEFINE_MAP(n_nodes_, length_, length_prev_, bending_rigidity_, penalty_param_, force_scale_, beta_tstep_,
-                       epsilon_, binding_site_, x_, A_, RHS_, force_operator_, bc_minus_, bc_plus_, xs_, xss_, xsss_,
+                       epsilon_, binding_site_, tension_, x_, A_, RHS_, force_operator_, bc_minus_, bc_plus_, xs_, xss_, xsss_,
                        xssss_, stokeslet_);
 #endif
 };

--- a/include/periphery.hpp
+++ b/include/periphery.hpp
@@ -27,8 +27,11 @@ class Periphery {
     /// @brief Get the number of nodes local to the MPI rank
     int get_local_node_count() const { return M_inv_.rows() / 3; };
 
-    /// @brief Get the size of the shell's contribution to the matrix problem solution
+    /// @brief Get the rank local size of shell's contribution to the matrix problem solution
     int get_local_solution_size() const { return M_inv_.rows(); };
+
+    /// @brief Get the global size of the shell's contribution to the matrix problem solution
+    int get_global_solution_size() const { return M_inv_.cols(); };
 
     Eigen::MatrixXd get_local_node_positions() const { return node_pos_; };
 
@@ -99,11 +102,11 @@ class Periphery {
 
     int n_nodes_global_ = 0; ///< Number of nodes across ALL MPI ranks
 #ifdef SKELLY_DEBUG
-    MSGPACK_DEFINE_MAP(RHS_);
-#else
     MSGPACK_DEFINE_MAP(solution_vec_, RHS_);
+#else
+    MSGPACK_DEFINE_MAP(solution_vec_);
 #endif
-    
+
   protected:
     int world_size_;
     int world_rank_ = -1;

--- a/include/periphery.hpp
+++ b/include/periphery.hpp
@@ -46,7 +46,8 @@ class Periphery {
     Eigen::MatrixXd node_pos_ = Eigen::MatrixXd(3, 0); ///< [3xn_nodes_local] matrix representing node positions
     Eigen::MatrixXd node_normal_;        ///< [3xn_nodes_local] matrix representing node normal vectors (inward facing)
     Eigen::VectorXd quadrature_weights_; ///< [n_nodes] array of 'far-field' quadrature weights
-    Eigen::VectorXd RHS_;                ///< Current 'right-hand-side' for matrix formulation of solver
+    Eigen::VectorXd RHS_;                ///< [ 3 * n_nodes ] Current 'right-hand-side' for matrix formulation of solver
+    Eigen::VectorXd solution_vec_;       ///< [ 3 * n_nodes ] Current 'solution' for matrix formulation of solver
 
     /// MPI_WORLD_SIZE array that specifies node_counts_[i] = number_of_nodes_on_rank_i*3
     Eigen::VectorXi node_counts_;
@@ -60,6 +61,8 @@ class Periphery {
     Eigen::VectorXi row_counts_;
     /// MPI_WORLD_SIZE+1 array that specifies row displacements. Is essentially the CDF of row_counts_
     Eigen::VectorXi row_displs_;
+
+    void step(VectorRef &solution) { solution_vec_ = solution; }
 
     virtual bool check_collision(const DeformableBody &body, double threshold) const {
         if (!n_nodes_global_)
@@ -97,7 +100,10 @@ class Periphery {
     int n_nodes_global_ = 0; ///< Number of nodes across ALL MPI ranks
 #ifdef SKELLY_DEBUG
     MSGPACK_DEFINE_MAP(RHS_);
+#else
+    MSGPACK_DEFINE_MAP(solution_vec_, RHS_);
 #endif
+    
   protected:
     int world_size_;
     int world_rank_ = -1;

--- a/include/system.hpp
+++ b/include/system.hpp
@@ -10,7 +10,7 @@ class Periphery;
 
 /// Namespace for System, which drives the simulation and handles communication (timestepping, data wrangling, etc)
 namespace System {
-void init(const std::string &input_file, bool resume_flag = false);
+void init(const std::string &input_file, bool resume_flag = false, bool post_process_flag = false);
 Params *get_params();
 BodyContainer *get_body_container();
 FiberContainer *get_fiber_container();
@@ -25,6 +25,7 @@ void dynamic_instability();
 void prep_state_for_solver();
 bool step();
 void run();
+void run_post_process();
 void write();
 bool check_collision();
 void backup();

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -163,7 +163,8 @@ MatrixXd BodyContainer::get_global_center_positions(const T &body_vec) const {
     return centers;
 }
 template MatrixXd BodyContainer::get_global_center_positions(const std::vector<std::shared_ptr<SphericalBody>> &) const;
-template MatrixXd BodyContainer::get_global_center_positions(const std::vector<std::shared_ptr<DeformableBody>> &) const;
+template MatrixXd
+BodyContainer::get_global_center_positions(const std::vector<std::shared_ptr<DeformableBody>> &) const;
 
 /// @brief Get center positions on rank 0, otherwise empty
 /// @param[in] std::vector of shared_ptr<DerivedBody>

--- a/src/fiber.cpp
+++ b/src/fiber.cpp
@@ -783,9 +783,12 @@ void FiberContainer::apply_bc_rectangular(double dt, MatrixRef &v_on_fibers, Mat
 void FiberContainer::step(VectorRef &fiber_sol) {
     size_t offset = 0;
     for (auto &fib : fibers) {
-        for (int i = 0; i < 3; ++i)
-            fib.x_.row(i) = fiber_sol.segment(offset + i * fib.n_nodes_, fib.n_nodes_);
-        offset += 4 * fib.n_nodes_;
+        for (int i = 0; i < 3; ++i) {
+            fib.x_.row(i) = fiber_sol.segment(offset, fib.n_nodes_);
+            offset += fib.n_nodes_;
+        }
+        fib.tension_ = fiber_sol.segment(offset, fib.n_nodes_);
+        offset += fib.n_nodes_;
     }
 }
 

--- a/src/fiber.cpp
+++ b/src/fiber.cpp
@@ -36,6 +36,7 @@ Fiber::Fiber(toml::value &fiber_table, double eta) {
 
     x_ = Eigen::Map<Eigen::ArrayXd>(x_array.data(), x_array.size());
     x_.resize(3, n_nodes_);
+    tension_ = Eigen::VectorXd::Zero(n_nodes_);
 
     init(eta);
 

--- a/src/periphery.cpp
+++ b/src/periphery.cpp
@@ -334,6 +334,8 @@ Periphery::Periphery(const std::string &precompute_file, const toml::value &peri
     const int n_nodes_big = n_nodes % world_size_;
     const int nrows_local = node_size_local;
 
+    solution_vec_ = Eigen::VectorXd::Zero(nrows_local);
+
     // TODO: prevent overflow for large matrices in periphery import
     node_counts_.resize(world_size_);
     node_displs_ = Eigen::VectorXi::Zero(world_size_ + 1);

--- a/src/skelly_sim.cpp
+++ b/src/skelly_sim.cpp
@@ -3,6 +3,7 @@
 #include <system.hpp>
 
 #include <spdlog/spdlog.h>
+#include <filesystem>
 #include <stdexcept>
 
 #include <Teuchos_CommandLineProcessor.hpp>
@@ -12,17 +13,25 @@ int main(int argc, char *argv[]) {
     int thread_level;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &thread_level);
 
-    std::string config_file;
-    int resume_flag = false;
+    std::string config_file = "skelly_config.toml";
+    bool resume_flag = false;
+    bool overwrite_flag = false;
     Teuchos::CommandLineProcessor cmdp(false, true);
     cmdp.setOption("config-file", &config_file, "TOML input file.");
-    cmdp.setOption("resume-flag", &resume_flag, "Flag to resume simulation.");
+    cmdp.setOption("resume", "no-resume", &resume_flag, "Supply to resume simulation.");
+    cmdp.setOption("overwrite", "no-overwrite", &overwrite_flag, "Supply to overwrite existing simulation.");
     if (cmdp.parse(argc, argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
         MPI_Finalize();
         return EXIT_FAILURE;
     }
 
     try {
+        if (resume_flag && overwrite_flag)
+            throw std::runtime_error("Can't resume and overwrite simultaneously.");
+        namespace fs = std::filesystem;
+        if (!overwrite_flag && (fs::exists(fs::path{"skelly_sim.out"}) || fs::exists(fs::path{"skelly_sim.vf"}))
+            throw std::runtime_error("Existing trajectory detected. Supply --overwrite flag to overwrite.");
+
         System::init(config_file, resume_flag);
         System::run();
     } catch (const std::runtime_error &e) {

--- a/src/skelly_sim.cpp
+++ b/src/skelly_sim.cpp
@@ -2,8 +2,8 @@
 
 #include <system.hpp>
 
-#include <spdlog/spdlog.h>
 #include <filesystem>
+#include <spdlog/spdlog.h>
 #include <stdexcept>
 
 #include <Teuchos_CommandLineProcessor.hpp>
@@ -16,10 +16,12 @@ int main(int argc, char *argv[]) {
     std::string config_file = "skelly_config.toml";
     bool resume_flag = false;
     bool overwrite_flag = false;
+    bool post_process_flag = false;
     Teuchos::CommandLineProcessor cmdp(false, true);
     cmdp.setOption("config-file", &config_file, "TOML input file.");
     cmdp.setOption("resume", "no-resume", &resume_flag, "Supply to resume simulation.");
     cmdp.setOption("overwrite", "no-overwrite", &overwrite_flag, "Supply to overwrite existing simulation.");
+    cmdp.setOption("post-process", "no-post-process", &post_process_flag, "Supply to post-process existing sim.");
     if (cmdp.parse(argc, argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
         MPI_Finalize();
         return EXIT_FAILURE;
@@ -29,11 +31,24 @@ int main(int argc, char *argv[]) {
         if (resume_flag && overwrite_flag)
             throw std::runtime_error("Can't resume and overwrite simultaneously.");
         namespace fs = std::filesystem;
-        if (!overwrite_flag && (fs::exists(fs::path{"skelly_sim.out"}) || fs::exists(fs::path{"skelly_sim.vf"}))
-            throw std::runtime_error("Existing trajectory detected. Supply --overwrite flag to overwrite.");
+        if (!post_process_flag) {
+            if (!overwrite_flag && (fs::exists(fs::path{"skelly_sim.out"}) || fs::exists(fs::path{"skelly_sim.vf"})))
+                throw std::runtime_error("Existing trajectory detected. Supply --overwrite flag to overwrite.");
+        }
+        else {
+            if (!fs::exists(fs::path{"skelly_sim.out"}))
+                throw std::runtime_error("No trajectory detected for post-process.");
+            if (resume_flag)
+                throw std::runtime_error("--post-process and --resume are mutually exclusive.");
+            if (overwrite_flag)
+                throw std::runtime_error("--post-process and --overwrite are mutually exclusive.");
+        }
 
-        System::init(config_file, resume_flag);
-        System::run();
+        System::init(config_file, resume_flag, post_process_flag);
+        if (post_process_flag)
+            System::run_post_process();
+        else
+            System::run();
     } catch (const std::runtime_error &e) {
         // Warning: Critical only catches things on rank 0, so this may or may not print, if
         // some random rank throws an error. This is the same reason we use MPI_Abort: all

--- a/src/spherical_body.cpp
+++ b/src/spherical_body.cpp
@@ -14,6 +14,7 @@ void SphericalBody::step(double dt, VectorRef &body_solution) {
 
     Eigen::Vector3d body_velocity = body_solution.segment(sol_offset, 3);
     Eigen::Vector3d body_angular_velocity = body_solution.segment(sol_offset + 3, 3);
+    solution_vec_ = body_solution;
 
     Eigen::Vector3d x_new = position_ + body_velocity * dt;
     Eigen::Vector3d phi = body_angular_velocity * dt;

--- a/src/spherical_body.cpp
+++ b/src/spherical_body.cpp
@@ -64,6 +64,7 @@ Eigen::VectorXd SphericalBody::matvec(MatrixRef &v_body, VectorRef &x_body) cons
 void SphericalBody::min_copy(const std::shared_ptr<SphericalBody> &other) {
     this->position_ = other->position_;
     this->orientation_ = other->orientation_;
+    this->solution_vec_ = other->solution_vec_;
 }
 
 /// @brief Update internal SphericalBody::K_ matrix variable

--- a/src/spherical_body.cpp
+++ b/src/spherical_body.cpp
@@ -28,7 +28,7 @@ void SphericalBody::step(double dt, VectorRef &body_solution) {
         ss << x_new.transpose();
         spdlog::debug("Moving body {}: [{}]", (void *)this, ss.str());
 
-        move(x_new, orientation_new);
+        place(x_new, orientation_new);
     }
 }
 
@@ -139,7 +139,7 @@ void SphericalBody::update_RHS(MatrixRef &v_on_body) {
 /// SphericalBody::node_normals_, SphericalBody::nucleation_sites_
 /// @param[in] new_pos new lab frame position to move the body centroid
 /// @param[in] new_orientation new orientation of the body
-void SphericalBody::move(const Eigen::Vector3d &new_pos, const Eigen::Quaterniond &new_orientation) {
+void SphericalBody::place(const Eigen::Vector3d &new_pos, const Eigen::Quaterniond &new_orientation) {
     position_ = new_pos;
     orientation_ = new_orientation;
 
@@ -233,7 +233,7 @@ SphericalBody::SphericalBody(const toml::value &body_table, const Params &params
     if (body_table.contains("external_force"))
         external_force_ = convert_array<>(body_table.at("external_force").as_array());
 
-    move(position_, orientation_);
+    place(position_, orientation_);
 
     update_cache_variables(params.eta);
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -4,6 +4,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -959,7 +959,9 @@ Eigen::MatrixXd VelocityField::make_grid() {
                         for (int k = 0; k < n_points; ++k) {
                             Vector3l coord_i = Vector3l{i, j, k} + bottom_left;
                             long int key = key_map[0] * coord_i[0] + key_map[1] * coord_i[1] + key_map[2] * coord_i[2];
-                            grid_map[key] = res * coord_i.cast<double>();
+                            Eigen::Vector3d test_point = res * coord_i.cast<double>();
+                            if (!shell_->check_collision(test_point, 0.0))
+                                grid_map[key] = test_point;
                         }
                     }
                 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -251,7 +251,7 @@ class TrajectoryReader {
 
 /// @brief Set system state to last state found in trajectory files
 ///
-/// @param[in] if_file input file name of trajectory file for this rank
+/// @param[in] input_file input file name of trajectory file for this rank
 void resume_from_trajectory(std::string input_file) {
     TrajectoryReader trajectory(input_file);
     while (trajectory.read_next_frame()) {

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -116,7 +116,6 @@ void write() {
         std::size_t offset = 0;
 
         output_map_t to_write{properties.time, properties.dt, fc_global, bc_global};
-
         for (int i = 0; i < size_; ++i) {
             msgpack::unpack(oh, (char *)msg.data(), msg.size(), offset);
             msgpack::object obj = oh.get();

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -228,12 +228,12 @@ class TrajectoryReader {
         for (int i = 0; i < bc_.deformable_bodies.size(); ++i)
             bc_.deformable_bodies[i]->min_copy(min_state.bodies.deformable_bodies[i]);
         output_map.rng_state = min_state.rng_state;
-        if (size_ > min_state.rng_state.size() && !silence_output) {
+        if (size_ > min_state.rng_state.size()) {
             spdlog::error(
                 "More MPI ranks provided than previous run for resume. This is currently unsupported for RNG reasons.");
             MPI_Finalize();
             exit(1);
-        } else if (size_ < min_state.rng_state.size()) {
+        } else if (size_ < min_state.rng_state.size() && !silence_output) {
             spdlog::warn(
                 "Fewer MPI ranks provided than previous run for resume. This will be non-deterministic if using "
                 "the RNG. This isn't really a problem, but runs will not be exactly reproducable.");

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1110,6 +1110,7 @@ bool step() {
     fc_.step(fiber_sol);
     bc_.step(body_sol, dt);
     fc_.repin_to_bodies(bc_);
+    shell_->step(shell_sol);
 
     return converged;
 }


### PR DESCRIPTION
This PR aims to address the issue of post-processing, mostly with respect to velocity fields. This is being tackled on multiple fronts - visualization, input, storage layout, and handling post-processing as similarly to the simulation as possible (avoiding duplicate code). 

Velocity fields actually require various state that had not been stored prior to reproduce that complicates code re-use. The velocity field is built both from position data and the solution data that resulted in that position (this includes velocities, densities, etc). This needs to be marshaled from multiple ranks into one rank, and then distributed back at post-processing time. Since this data was temporary and a single array is the natural representation of it, it would make sense to just save this array, but this would be wasteful since a lot of that data is redundant (notably fiber positions). I chose to copy the data back from the solution vector to each object in the relevant fields. For fibers, this meant adding a "tension" attribute. Both the periphery and body just store the solution vector directly, since there was very little redundant data in the bodies (just pos/orientation), and the shell had no output at all prior.

Issues that still remain:
- [ ] Verification
- [ ] Visualization (in blender. paraview works, but I much prefer the blender workflow so i'm going to try to get this going)
- [ ] Storage: moving volumes (boxes surrounding moving bodies) currently require an unordered point list for the field to remove redundant points. there is definitely a more efficient algorithm to map overlapping boxes to unique ordered points, which would nearly halve the storage cost for moving volumes. worse - i'm pretty sure i use this same algorithm for a single box to remove points outside the periphery
- [x] distribute computation? I pile up all the target points on rank 0. Edit: apparently I already did this a while ago.