### PR TITLE
core: implement scheme as probably wrong forward-euler

### DIFF
--- a/include/fiber.hpp
+++ b/include/fiber.hpp
@@ -118,6 +118,9 @@ class Fiber {
             x_ = Eigen::MatrixXd::Zero(3, n_nodes_);
             x_.row(0) = Eigen::ArrayXd::LinSpaced(n_nodes_, 0, 1.0).transpose();
         }
+        if (tension_.size() != n_nodes_) {
+            tension_ = Eigen::VectorXd::Zero(n_nodes_);
+        }
 
         xs_.resize(3, n_nodes_);
         xss_.resize(3, n_nodes_);

--- a/include/fiber.hpp
+++ b/include/fiber.hpp
@@ -213,7 +213,7 @@ class FiberContainer {
     Eigen::MatrixXd generate_constant_force() const;
     const Eigen::MatrixXd &get_local_node_positions() const { return r_fib_local_; };
     Eigen::VectorXd get_RHS() const;
-    Eigen::MatrixXd flow(const MatrixRef &r_trg, const MatrixRef &forces, double eta, bool subtract_self = true) const;
+    Eigen::MatrixXd flow(const MatrixRef &r_trg, const MatrixRef &forces, double eta, bool subtract_self) const;
     Eigen::VectorXd matvec(VectorRef &x_all, MatrixRef &v_fib) const;
     Eigen::MatrixXd apply_fiber_force(VectorRef &x_all) const;
     Eigen::VectorXd apply_preconditioner(VectorRef &x_all) const;

--- a/include/fiber.hpp
+++ b/include/fiber.hpp
@@ -135,7 +135,7 @@ class Fiber {
     }
 
 
-    Eigen::VectorXd matvec(VectorRef x, MatrixRef v) const;
+    Eigen::VectorXd matvec(VectorRef x) const;
     void update_preconditioner();
     void update_force_operator();
     void update_boundary_conditions(Periphery &shell);
@@ -217,7 +217,7 @@ class FiberContainer {
     const Eigen::MatrixXd &get_local_node_positions() const { return r_fib_local_; };
     Eigen::VectorXd get_RHS() const;
     Eigen::MatrixXd flow(const MatrixRef &r_trg, const MatrixRef &forces, double eta, bool subtract_self) const;
-    Eigen::VectorXd matvec(VectorRef &x_all, MatrixRef &v_fib) const;
+    Eigen::VectorXd matvec(VectorRef &x_all) const;
     Eigen::MatrixXd apply_fiber_force(VectorRef &x_all) const;
     Eigen::VectorXd apply_preconditioner(VectorRef &x_all) const;
 

--- a/include/periphery.hpp
+++ b/include/periphery.hpp
@@ -38,7 +38,7 @@ class Periphery {
     Eigen::VectorXd get_RHS() const { return RHS_; };
 
     Eigen::VectorXd apply_preconditioner(VectorRef &x) const;
-    Eigen::VectorXd matvec(VectorRef &x_local, MatrixRef &v_local) const;
+    Eigen::VectorXd matvec(VectorRef &x_local) const;
 
     /// pointer to FMM object (pointer to avoid constructing object with empty Periphery)
     kernels::Evaluator stresslet_kernel_;

--- a/include/system.hpp
+++ b/include/system.hpp
@@ -25,7 +25,7 @@ Periphery *get_shell();
 PointSourceContainer *get_point_source_container();
 toml::value *get_param_table();
 
-std::tuple<int, int> get_local_solution_sizes();
+std::tuple<int> get_local_solution_sizes();
 Eigen::VectorXd apply_preconditioner(VectorRef &x);
 Eigen::VectorXd apply_matvec(VectorRef &x);
 void prep_state_for_solver();
@@ -43,8 +43,8 @@ Eigen::VectorXd get_fiber_RHS();
 Eigen::VectorXd get_shell_RHS();
 struct properties_t &get_properties();
 Eigen::VectorXd &get_curr_solution();
-std::tuple<VectorMap, VectorMap> get_solution_maps(double *x);
-std::tuple<CVectorMap, CVectorMap> get_solution_maps(const double *x);
+std::tuple<VectorMap> get_solution_maps(double *x);
+std::tuple<CVectorMap> get_solution_maps(const double *x);
 Eigen::MatrixXd velocity_at_targets(MatrixRef &r_trg);
 
 }; // namespace System

--- a/src/core/fiber.cpp
+++ b/src/core/fiber.cpp
@@ -206,6 +206,32 @@ void Fiber::update_RHS(double dt, MatrixRef &flow, MatrixRef &f_external) {
     RHS_.segment(3 * np, np) = -penalty_param_ * VectorXd::Ones(np);
 
     if (flow.size()) {
+        const int bc_start_i = 4 * np - 14;
+        MatrixXd xsDs = (D_1.array().colwise() * xs_.row(0).transpose().array()).transpose();
+        MatrixXd ysDs = (D_1.array().colwise() * xs_.row(1).transpose().array()).transpose();
+        MatrixXd zsDs = (D_1.array().colwise() * xs_.row(2).transpose().array()).transpose();
+
+        VectorXd vT = VectorXd(np * 4);
+        VectorXd v_x = flow.row(0).transpose();
+        VectorXd v_y = flow.row(1).transpose();
+        VectorXd v_z = flow.row(2).transpose();
+
+        vT.segment(0 * np, np) = v_x;
+        vT.segment(1 * np, np) = v_y;
+        vT.segment(2 * np, np) = v_z;
+        vT.segment(3 * np, np) = xsDs * v_x + ysDs * v_y + zsDs * v_z;
+
+        VectorXd vT_in = VectorXd::Zero(4 * np);
+        vT_in.segment(0, bc_start_i) = mats.P_downsample_bc * vT;
+
+        VectorXd xs_vT = VectorXd::Zero(4 * np); // from attachments
+        const int minus_node = 0;
+
+        // FIXME: Does this imply always having velocity boundary conditions?
+        xs_vT(bc_start_i + 3) = flow.col(minus_node).dot(xs_.col(minus_node));
+
+        RHS_ += vT_in - xs_vT;
+
         RHS_.segment(0 * np, np) += flow.row(0);
         RHS_.segment(1 * np, np) += flow.row(1);
         RHS_.segment(2 * np, np) += flow.row(2);
@@ -259,34 +285,7 @@ void Fiber::update_RHS(double dt, MatrixRef &flow, MatrixRef &f_external) {
 }
 
 VectorXd Fiber::matvec(VectorRef x, MatrixRef v) const {
-    auto &mats = matrices_.at(n_nodes_);
-    const int np = n_nodes_;
-    const int bc_start_i = 4 * np - 14;
-    MatrixXd D_1 = mats.D_1_0 * std::pow(2.0 / length_, 1);
-    MatrixXd xsDs = (D_1.array().colwise() * xs_.row(0).transpose().array()).transpose();
-    MatrixXd ysDs = (D_1.array().colwise() * xs_.row(1).transpose().array()).transpose();
-    MatrixXd zsDs = (D_1.array().colwise() * xs_.row(2).transpose().array()).transpose();
-
-    VectorXd vT = VectorXd(np * 4);
-    VectorXd v_x = v.row(0).transpose();
-    VectorXd v_y = v.row(1).transpose();
-    VectorXd v_z = v.row(2).transpose();
-
-    vT.segment(0 * np, np) = v_x;
-    vT.segment(1 * np, np) = v_y;
-    vT.segment(2 * np, np) = v_z;
-    vT.segment(3 * np, np) = xsDs * v_x + ysDs * v_y + zsDs * v_z;
-
-    VectorXd vT_in = VectorXd::Zero(4 * np);
-    vT_in.segment(0, bc_start_i) = mats.P_downsample_bc * vT;
-
-    VectorXd xs_vT = VectorXd::Zero(4 * np); // from attachments
-    const int minus_node = 0;
-
-    // FIXME: Does this imply always having velocity boundary conditions?
-    xs_vT(bc_start_i + 3) = v.col(minus_node).dot(xs_.col(minus_node));
-
-    return A_ * x - vT_in + xs_vT;
+    return A_ * x;
 }
 
 /// @brief Calculate the force operator cache variable

--- a/src/core/fiber.cpp
+++ b/src/core/fiber.cpp
@@ -31,7 +31,10 @@ const std::string Fiber::BC_name[] = {"Force", "Torque", "Velocity", "AngularVel
 Fiber::Fiber(toml::value &fiber_table, double eta) {
     std::vector<double> x_array = toml::find<std::vector<double>>(fiber_table, "x");
     n_nodes_ = x_array.size() / 3;
+    std::vector<double> tension_array = toml::find_or(fiber_table, "tension", std::vector<double>{});
     x_ = Eigen::Map<Eigen::MatrixXd>(x_array.data(), 3, n_nodes_);
+    if (tension_array.size())
+        tension_ = Eigen::Map<Eigen::VectorXd>(tension_array.data(), n_nodes_);
 
     init();
 

--- a/src/core/fiber.cpp
+++ b/src/core/fiber.cpp
@@ -233,16 +233,7 @@ void Fiber::update_RHS(double dt, MatrixRef &flow, MatrixRef &f_external) {
         // FIXME: Does this imply always having velocity boundary conditions?
         xs_vT(bc_start_i + 3) = flow.col(minus_node).dot(xs_.col(minus_node));
 
-        RHS_ += vT_in - xs_vT;
-
-        RHS_.segment(0 * np, np) += flow.row(0);
-        RHS_.segment(1 * np, np) += flow.row(1);
-        RHS_.segment(2 * np, np) += flow.row(2);
-
-        RHS_.segment(3 * np, np) += (xs_x.transpose() * (flow.row(0) * D_1.matrix()).array() +
-                                     xs_y.transpose() * (flow.row(1) * D_1.matrix()).array() +
-                                     xs_z.transpose() * (flow.row(2) * D_1.matrix()).array())
-                                        .matrix();
+        RHS_ += -vT + vT_in - xs_vT;
     }
     if (f_external.size()) {
         ArrayXXd fs = f_external * D_1;

--- a/src/core/fiber_container.cpp
+++ b/src/core/fiber_container.cpp
@@ -71,14 +71,14 @@ VectorXd FiberContainer::apply_preconditioner(VectorRef &x_all) const {
     return y;
 }
 
-VectorXd FiberContainer::matvec(VectorRef &x_all, MatrixRef &v_fib) const {
+VectorXd FiberContainer::matvec(VectorRef &x_all) const {
     VectorXd res = VectorXd::Zero(get_local_solution_size());
 
     size_t offset = 0;
     int i_fib = 0;
     for (const auto &fib : *this) {
         const int np = fib.n_nodes_;
-        res.segment(offset, 4 * np) = fib.matvec(x_all.segment(offset, 4 * np), v_fib.block(0, i_fib, 3, np));
+        res.segment(offset, 4 * np) = fib.matvec(x_all.segment(offset, 4 * np));
 
         i_fib++;
         offset += 4 * np;

--- a/src/core/periphery.cpp
+++ b/src/core/periphery.cpp
@@ -28,15 +28,14 @@ Eigen::VectorXd Periphery::apply_preconditioner(VectorRef &x_local) const {
 /// @param[in] x_local [3 * n_nodes_local] vector of 'x' local to this rank
 /// @param[in] v_local [3 * n_nodes_local] vector of velocities 'v' local to this rank
 /// @return [3 * n_nodes_local] vector of A * x_local
-Eigen::VectorXd Periphery::matvec(VectorRef &x_local, MatrixRef &v_local) const {
+Eigen::VectorXd Periphery::matvec(VectorRef &x_local) const {
     if (!n_nodes_global_)
         return Eigen::VectorXd();
     assert(x_local.size() == get_local_solution_size());
-    assert(v_local.size() == get_local_solution_size());
     Eigen::VectorXd x_shell(3 * n_nodes_global_);
     MPI_Allgatherv(x_local.data(), node_counts_[world_rank_], MPI_DOUBLE, x_shell.data(), node_counts_.data(),
                    node_displs_.data(), MPI_DOUBLE, MPI_COMM_WORLD);
-    return stresslet_plus_complementary_ * x_shell + CVectorMap(v_local.data(), v_local.size());
+    return stresslet_plus_complementary_ * x_shell;
 }
 
 /// @brief Calculate velocity at target coordinates due to the periphery

--- a/src/core/solver_hydro.cpp
+++ b/src/core/solver_hydro.cpp
@@ -13,8 +13,8 @@ P_inv_hydro::P_inv_hydro(const Teuchos::RCP<const Teuchos::Comm<int>> comm) : co
     TEUCHOS_TEST_FOR_EXCEPTION(comm.is_null(), std::invalid_argument,
                                "P_inv_hydro constructor: The input Teuchos::Comm object must be nonnull.");
     const global_ordinal_type indexBase = 0;
-    const auto [fiber_sol_size, shell_sol_size] = System::get_local_solution_sizes();
-    const int local_size = fiber_sol_size + shell_sol_size;
+    const auto [fiber_sol_size] = System::get_local_solution_sizes();
+    const int local_size = fiber_sol_size;
 
     // Construct a map for our block row distribution
     opMap_ = rcp(new map_type(Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(), local_size, indexBase, comm));
@@ -32,8 +32,8 @@ A_fiber_hydro::A_fiber_hydro(const Teuchos::RCP<const Teuchos::Comm<int>> comm) 
     TEUCHOS_TEST_FOR_EXCEPTION(comm.is_null(), std::invalid_argument,
                                "A_fiber_hydro constructor: The input Comm object must be nonnull.");
     const global_ordinal_type indexBase = 0;
-    const auto [fiber_sol_size, shell_sol_size] = System::get_local_solution_sizes();
-    const int local_size = fiber_sol_size + shell_sol_size;
+    const auto [fiber_sol_size] = System::get_local_solution_sizes();
+    const int local_size = fiber_sol_size;
 
     // Construct a map for our block row distribution
     opMap_ = rcp(new map_type(Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(), local_size, indexBase, comm));
@@ -49,13 +49,11 @@ void A_fiber_hydro::apply(const MV &X, MV &Y, Teuchos::ETransp mode, scalar_type
 
 template <>
 void Solver<P_inv_hydro, A_fiber_hydro>::set_RHS() {
-    const auto [fib_sol_size, shell_sol_size] = System::get_local_solution_sizes();
+    const auto [fib_sol_size] = System::get_local_solution_sizes();
     VectorMap RHS_fib(RHS_->getDataNonConst(0).getRawPtr(), fib_sol_size);
-    VectorMap RHS_shell(RHS_->getDataNonConst(0).getRawPtr() + fib_sol_size, shell_sol_size);
 
     // Initialize GMRES RHS vector
     RHS_fib = System::get_fiber_RHS();
-    RHS_shell = System::get_shell_RHS();
 }
 
 template <>

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -272,7 +272,7 @@ void prep_state_for_solver() {
     if (shell_->is_active()) {
         CVectorMap shell_velocities_flat(v_all.data() + 3 * fib_node_count, 3 * shell_node_count);
         shell_->solution_vec_ = shell_->M_inv_ * shell_velocities_flat;
-        v_fib = shell_->flow(r_fibers, shell_->solution_vec_, params_.eta);
+        v_fib = -shell_->flow(r_fibers, shell_->solution_vec_, params_.eta);
     }
     else {
         v_fib = MatrixXd::Zero(3, fib_node_count);
@@ -282,7 +282,7 @@ void prep_state_for_solver() {
 
     MatrixXd external_force_fibers = MatrixXd::Zero(3, fib_node_count);
     MatrixXd external_velocity_fibers = MatrixXd::Zero(3, fib_node_count);
-    fc_.update_RHS(properties.dt, -v_fib, external_force_fibers);
+    fc_.update_RHS(properties.dt, v_fib, external_force_fibers);
     fc_.update_boundary_conditions(*shell_);
     fc_.apply_bc_rectangular(properties.dt, external_velocity_fibers, external_force_fibers);
 }

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -281,9 +281,10 @@ void prep_state_for_solver() {
     }
 
     MatrixXd external_force_fibers = MatrixXd::Zero(3, fib_node_count);
-    fc_.update_RHS(properties.dt, v_shell2fib, external_force_fibers);
+    MatrixXd external_velocity_fibers = MatrixXd::Zero(3, fib_node_count);
+    fc_.update_RHS(properties.dt, -v_shell2fib, external_force_fibers);
     fc_.update_boundary_conditions(*shell_);
-    fc_.apply_bc_rectangular(properties.dt, v_shell2fib, external_force_fibers);
+    fc_.apply_bc_rectangular(properties.dt, external_velocity_fibers, external_force_fibers);
 }
 
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -262,6 +262,7 @@ void prep_state_for_solver() {
         x_fibers.segment(offset + n * 0, n) = fiber.x_.row(0);
         x_fibers.segment(offset + n * 1, n) = fiber.x_.row(1);
         x_fibers.segment(offset + n * 2, n) = fiber.x_.row(2);
+        x_fibers.segment(offset + n * 3, n) = fiber.tension_;
         offset += 4 * n;
     }
     MatrixXd force_fibers = fc_.apply_fiber_force(x_fibers);

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -274,12 +274,13 @@ void prep_state_for_solver() {
     CVectorMap shell_velocities_flat(v_all.data() + 3 * fib_node_count, 3 * shell_node_count);
     shell_->solution_vec_ = shell_->M_inv_ * shell_velocities_flat;
     v_fibers_ = shell_->flow(fc_.get_local_node_positions(), shell_->solution_vec_, params_.eta);
-    v_fibers_ += v_all.block(0, 0, 3, fib_node_count);
 
     MatrixXd external_force_fibers = MatrixXd::Zero(3, fib_node_count);
     fc_.update_RHS(properties.dt, v_fibers_, external_force_fibers);
     fc_.update_boundary_conditions(*shell_);
     fc_.apply_bc_rectangular(properties.dt, v_fibers_, external_force_fibers);
+
+    v_fibers_ += v_all.block(0, 0, 3, fib_node_count);
 }
 
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -282,7 +282,11 @@ void prep_state_for_solver() {
 
     MatrixXd external_force_fibers = MatrixXd::Zero(3, fib_node_count);
     MatrixXd external_velocity_fibers = MatrixXd::Zero(3, fib_node_count);
-    fc_.update_RHS(properties.dt, v_fib, external_force_fibers);
+    MatrixXd motor_force_fibers = params_.implicit_motor_activation_delay > properties.time
+                                      ? MatrixXd::Zero(3, fib_node_count)
+                                      : fc_.generate_constant_force();
+
+    fc_.update_RHS(properties.dt, v_fib, motor_force_fibers);
     fc_.update_boundary_conditions(*shell_);
     fc_.apply_bc_rectangular(properties.dt, external_velocity_fibers, external_force_fibers);
 }

--- a/src/core/trajectory_reader.cpp
+++ b/src/core/trajectory_reader.cpp
@@ -155,8 +155,8 @@ void TrajectoryReader::unpack_current_frame(bool silence_output) {
     if (shell.is_active())
         shell.solution_vec_ = min_state.shell.solution_vec_.segment(shell.node_displs_[rank], shell.node_counts_[rank]);
 
-    auto [fiber_sol, shell_sol] = System::get_solution_maps(System::get_curr_solution().data());
-    shell_sol = shell.solution_vec_;
+    auto [fiber_sol] = System::get_solution_maps(System::get_curr_solution().data());
+    // shell_sol = shell.solution_vec_;
 
     std::size_t fiber_offset = 0;
     for (auto &fib : fc.fibers) {

--- a/src/skelly_sim/skelly_config.py
+++ b/src/skelly_sim/skelly_config.py
@@ -273,6 +273,8 @@ class Fiber():
     x : List[float], default: :obj:`[]`, units: :obj:`μm`
         List of node positions in [x0,y0,z0,x1,y1,z1...] order. Extreme care must be taken when setting this since the length constraint
         can generate massive tensions with poor input. See examples.
+    tension : List[float], default: :obj:`[]`, units: :obj:`pN·μm⁻¹`
+        Optional list of node tensions [T_0,T_1,T_2,...T_{n_nodes-1}]
     """
     n_nodes: int = 32
     parent_site: int = -1
@@ -282,6 +284,7 @@ class Fiber():
     length: float = 1.0
     minus_clamped: bool = False
     x: List[float] = field(default_factory=list)
+    tension: List[float] = field(default_factory=list)
 
     def fill_node_positions(self, x0: np.array, normal: np.array):
         """


### PR DESCRIPTION
Attempting to fix the trial of forward-euler. Reference data supplied from main branch simulation of bent rod in periphery relaxing from bent configuration. Attached is the initial config file along with the data and script used to plot the endpoint data.

![image](https://user-images.githubusercontent.com/364498/215763998-100c9eb8-f685-4456-a0bb-da88d646ae05.png)
[config_refdata_and_plot.zip](https://github.com/flatironinstitute/SkellySim/files/10546485/config_refdata_and_plot.zip)

