### PR TITLE
Fiber inheritance refactor

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -733,7 +733,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src include
+INPUT                  = src src/core include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/include/fiber.hpp
+++ b/include/fiber.hpp
@@ -250,4 +250,11 @@ class FiberContainer {
     MSGPACK_DEFINE(fibers);
 };
 
+/// @brief Finite-difference fiber
+class FiniteDifferenceFiber : public Fiber {
+  public:
+    // Input parameters
+    double penalty_param_ = 500.0;  ///< @brief Tension penalty parameter for linear operator @see update_linear_operator
+};
+
 #endif

--- a/include/fiber.hpp
+++ b/include/fiber.hpp
@@ -10,6 +10,9 @@
 #include <kernels.hpp>
 #include <params.hpp>
 
+/// @file
+/// @brief Declares classes for Fiber and FiberContainer 
+
 class Periphery;
 class BodyContainer;
 
@@ -42,7 +45,7 @@ class Fiber {
 
     double v_growth_ = 0.0;      ///< instantaneous fiber growth velocity
 
-    /// @brief Coefficient for SBT @see Fiber::init
+    /// @brief Coefficient for SBT radius@see Fiber::init
     /// \f[ c_0 = -\frac{log(e \epsilon^\ell)}{8 \pi \eta}\f]
     double c_0_;
 
@@ -116,9 +119,9 @@ class Fiber {
 
     bool active() const { return true; }
 
-    ///< @brief Set some default values and resize arrays
+    /// @brief Set some default values and resize arrays
     ///
-    ///< _MUST_ be called from constructors.
+    /// _MUST_ be called from constructors.
     ///
     /// Initializes: Fiber::x_, Fiber::xs_, Fiber::xss_, Fiber::xsss_, Fiber::xssss_, Fiber::c_0_, Fiber::c_1_
     void init() {
@@ -165,7 +168,7 @@ class Fiber {
 
 MSGPACK_ADD_ENUM(Fiber::BC);
 
-/// Class to hold the fiber objects.
+/// @brief Class to hold the fiber objects.
 ///
 /// The container object is designed to work on fibers local to that MPI rank. Each MPI rank
 /// should have its own container, with its own unique fibers. The container object does not

--- a/include/params.hpp
+++ b/include/params.hpp
@@ -20,6 +20,7 @@ class Params {
     bool periphery_interaction_flag;
     bool adaptive_timestep_flag;
     std::string pair_evaluator;
+    std::string fiber_type;
 
     periphery_binding_t periphery_binding{
         .polar_angle_start = 0.0,
@@ -61,6 +62,8 @@ class Params {
 
     Params() = default;
     Params(toml::value &param_table);
+
+    void Print();
 };
 
 #endif

--- a/include/skelly_sim.hpp
+++ b/include/skelly_sim.hpp
@@ -21,6 +21,9 @@
 #include <spdlog/spdlog.h>
 #include <mpi.h>
 
+/// @file
+/// @brief Header for SkellySim
+
 typedef Eigen::Map<Eigen::VectorXd> VectorMap;
 typedef Eigen::Map<const Eigen::VectorXd> CVectorMap;
 typedef Eigen::Map<Eigen::ArrayXd> ArrayMap;

--- a/scripts/skelly_blend.py
+++ b/scripts/skelly_blend.py
@@ -40,7 +40,7 @@ def _create_sphere(position : np.array, radius : float, name : str, material : s
     bmesh.ops.create_uvsphere(bm,
                               u_segments=64,
                               v_segments=32,
-                              diameter=radius)
+                              radius=radius)
 
     if half:
         modifier = sphere.modifiers.new(name="Solidify", type="SOLIDIFY")

--- a/src/core/fiber.cpp
+++ b/src/core/fiber.cpp
@@ -12,7 +12,7 @@
 #include <toml.hpp>
 
 /// @file
-/// @brief Implement Fiber and FiberContainer classes and associated functions
+/// @brief Implementation for Fiber class
 
 using Eigen::ArrayXd;
 using Eigen::ArrayXXd;

--- a/src/core/fiber_container.cpp
+++ b/src/core/fiber_container.cpp
@@ -9,6 +9,9 @@
 #include <system.hpp>
 #include <utils.hpp>
 
+/// @file
+/// @brief Implementation for FiberContainer class
+
 using Eigen::ArrayXd;
 using Eigen::ArrayXXd;
 using Eigen::MatrixXd;

--- a/src/core/fiber_container.cpp
+++ b/src/core/fiber_container.cpp
@@ -79,14 +79,18 @@ VectorXd FiberContainer::matvec(VectorRef &x_all, MatrixRef &v_fib, MatrixRef &v
     VectorXd res = VectorXd::Zero(get_local_solution_size());
 
     size_t offset = 0;
+    size_t offset_node = 0;
     int i_fib = 0;
     for (const auto &fib : *this) {
         const int np = fib.n_nodes_;
         res.segment(offset, 4 * np) =
-            fib.matvec(x_all.segment(offset, 4 * np), v_fib.block(0, i_fib, 3, np), v_fib_boundary.col(i_fib));
+            fib.matvec(x_all.segment(offset, 4 * np), v_fib.block(0, offset_node, 3, np), v_fib_boundary.col(i_fib));
+        // FIXME: This is probably where the bug is, as it came from the offset variable
+        // FIXME: Setup an index so that we just know where nodes/solutions/etc start, rather than using offsets. Something like a node_start_map and a solution_start_map
 
         i_fib++;
         offset += 4 * np;
+        offset_node += np;
     }
 
     return res;
@@ -187,6 +191,7 @@ void FiberContainer::update_local_node_positions() {
     }
 }
 
+// FIXME: Make this so it gets abstracted away
 void FiberContainer::update_cache_variables(double dt, double eta) {
     for (auto &fib : *this) {
         fib.update_constants(eta);

--- a/src/core/params.cpp
+++ b/src/core/params.cpp
@@ -3,20 +3,20 @@
 Params::Params(toml::value &pt) {
     eta = toml::find_or(pt, "eta", 1.0);
     dt_initial = toml::find_or(pt, "dt_initial", 1E-2);
-    gmres_tol = toml::find_or(pt, "gmres_tol", 1E-10);
-    t_final = toml::find_or(pt, "t_final", 1.0);
-    fiber_error_tol = toml::find_or(pt, "fiber_error_tol", 1E-1);
+    dt_min = toml::find_or(pt, "dt_min", 1E-4);
     dt_max = toml::find_or(pt, "dt_max", 2.0);
     beta_up = toml::find_or(pt, "beta_up", 1.2);
     beta_down = toml::find_or(pt, "beta_down", 0.5);
-    seed = toml::find_or(pt, "seed", 1);
-    dt_min = toml::find_or(pt, "dt_min", 1E-4);
-    dt_write = toml::find_or(pt, "dt_write", 0.25);
-    implicit_motor_activation_delay = toml::find_or(pt, "implicit_motor_activation_delay", 0.0);
-    seed = toml::find_or(pt, "seed", 1);
-    periphery_interaction_flag = toml::find_or(pt, "periphery_interaction_flag", false);
     adaptive_timestep_flag = toml::find_or(pt, "adaptive_timestep_flag", true);
+    dt_write = toml::find_or(pt, "dt_write", 0.25);
+    t_final = toml::find_or(pt, "t_final", 1.0);
+    gmres_tol = toml::find_or(pt, "gmres_tol", 1E-10);
+    fiber_error_tol = toml::find_or(pt, "fiber_error_tol", 1E-1);
+    seed = toml::find_or(pt, "seed", 1);
+    implicit_motor_activation_delay = toml::find_or(pt, "implicit_motor_activation_delay", 0.0);
+    periphery_interaction_flag = toml::find_or(pt, "periphery_interaction_flag", false);
     pair_evaluator = toml::find_or(pt, "pair_evaluator", "FMM");
+    fiber_type = toml::find_or(pt, "fiber_type", "finite_difference");
 
     if (pt.contains("dynamic_instability")) {
         const auto &di = pt.at("dynamic_instability");
@@ -76,4 +76,27 @@ Params::Params(toml::value &pt) {
         fiber_periphery_interaction.f_0 = toml::find_or(fp, "f_0", fiber_periphery_interaction.f_0);
         fiber_periphery_interaction.l_0 = toml::find_or(fp, "l_0", fiber_periphery_interaction.l_0);
     }
+}
+
+void Params::Print() {
+    // Print out the information that we have on the system (only one, don't do it to global)
+    // XXX: Whenever you add a new variable, make sure to also add a print statement here!
+    spdlog::info("****** SkellySim {} ({}) ******", SKELLYSIM_VERSION, SKELLYSIM_COMMIT);
+    spdlog::info("******    Parameters     ******");
+    spdlog::info("eta                               = {}", eta);
+    spdlog::info("dt_initial                        = {}", dt_initial);
+    spdlog::info("dt_min                            = {}", dt_min);
+    spdlog::info("dt_max                            = {}", dt_max);
+    spdlog::info("beta_up                           = {}", beta_up);
+    spdlog::info("beta_down                         = {}", beta_down);
+    spdlog::info("adaptive_timestep_flag            = {}", adaptive_timestep_flag);
+    spdlog::info("dt_write                          = {}", dt_write);
+    spdlog::info("t_final                           = {}", t_final);
+    spdlog::info("gmres_tol                         = {}", gmres_tol);
+    spdlog::info("fiber_error_tol                   = {}", fiber_error_tol);
+    spdlog::info("seed                              = {}", seed);
+    spdlog::info("implicit_motor_activation_delay   = {}", implicit_motor_activation_delay);
+    spdlog::info("periphery_interaction_flag        = {}", periphery_interaction_flag);
+    spdlog::info("pair_evaluator                    = {}", pair_evaluator);
+    spdlog::info("fiber_type                        = {}", fiber_type);
 }

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -449,6 +449,8 @@ void prep_state_for_solver() {
     if (params_.periphery_interaction_flag && shell_->is_active()) {
         int i_col = 0;
 
+        // FIXME: MAke sure this is never being called until we can figure out the bodies thing
+        // Make sure it's not adding any numbers, etc
         for (const auto &fib : fc_.fibers) {
             external_force_fibers.block(0, i_col, 3, fib.n_nodes_) +=
                 shell_->fiber_interaction(fib, params_.fiber_periphery_interaction);
@@ -503,6 +505,7 @@ bool solve() {
 
     Solver<P_inv_hydro, A_fiber_hydro> solver_; /// < Wrapper class for solving system
     solver_.set_RHS();
+    // FIXME: Rename this, as it just packs up things for the solver, something like grab_RHS_from_system
 
     bool converged = solver_.solve();
     curr_solution_ = solver_.get_solution();
@@ -622,6 +625,19 @@ bool check_collision() {
         if (!collided && shell.check_collision(fiber.x_, threshold))
             collided = true;
 
+    //for (const auto &fiber : fc.fibers) {
+    //    if (fiber.is_minus_clamped()) {
+    //        if (!collided && shell.check_collision(fiber.x_.block(0, 1, 3, fiber.n_nodes_ - 1), threshold)) {
+    //            collided = true;
+    //        }
+    //    }
+    //    else  {
+    //        if (!collided && shell.check_collision(fiber.x_, threshold)) {
+    //            collided = true;
+    //        }
+    //    }
+    //}
+
     for (auto &body1 : bc.bodies)
         for (auto &body2 : bc.bodies)
             if (!collided && body1 != body2 && body1->check_collision(*body2, threshold))
@@ -683,6 +699,7 @@ void init(const std::string &input_file, bool resume_flag, bool listen_flag) {
 
     param_table_ = toml::parse(input_file);
     params_ = Params(param_table_.at("params"));
+    params_.Print();
     RNG::init(params_.seed);
 
     properties.dt = params_.dt_initial;

--- a/src/skelly_sim.cpp
+++ b/src/skelly_sim.cpp
@@ -9,6 +9,9 @@
 #include <Kokkos_Core.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 
+/// @file
+/// @brief Implementation of SkellySim
+
 int main(int argc, char *argv[]) {
     int thread_level;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &thread_level);

--- a/tests/combined/test_fiber_dualfilament.py
+++ b/tests/combined/test_fiber_dualfilament.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+from pathlib import Path
+
+from skelly_sim.reader import TrajectoryReader
+from skelly_sim.skelly_config import Config, Fiber, perturbed_fiber_positions
+from skelly_sim.testing import working_directory, sim_path, run_sim
+
+np.random.seed(100)
+config_file = 'skelly_config.toml'
+
+def gen_config(path: Path):
+    print("Generating config")
+    # create a config object and set the system parameters
+    config = Config()
+    config.params.eta = 1.0
+    config.params.dt_initial = 1E-1
+    config.params.dt_write = 1.0
+    config.params.t_final = 1E1
+    config.params.gmres_tol = 1E-10
+    config.params.seed = 130319
+    config.params.pair_evaluator = "CPU"
+    config.params.adaptive_timestep_flag = False
+
+    sigma = 0.0225
+    length = 2.0
+    bending_rigidity = 0.0025
+    n_nodes = 64
+
+    n_fibers = 2
+
+    config.fibers = [Fiber(
+        force_scale=-sigma,
+        length=length,
+        n_nodes=n_nodes,
+        bending_rigidity=bending_rigidity,
+        minus_clamped=True
+    ) for i in range(n_fibers)]
+
+    # Disrupt the first fiber only
+    x = perturbed_fiber_positions(0.01, length, np.array([0.0, 0.0, 0.0]), np.array([0.0, 0.0, 1.0]), n_nodes, np.array([1.0, 0.0, 0.0]))
+    config.fibers[0].x = x.ravel().tolist()
+    config.fibers[1].fill_node_positions(np.array([1.0, 0.0, 0.0]), np.array([0.0, 0.0, 1.0]))
+
+    config.save(path / config_file)
+
+    return True
+
+
+def deflection(path: Path=Path('.')):
+    print(f"Comparing deflection to previous results")
+    with working_directory(path):
+        traj = TrajectoryReader('skelly_config.toml')
+
+        traj.load_frame(-1)
+        x0 = traj['fibers'][0]['x_'][-1,0]
+        x1 = traj['fibers'][1]['x_'][-1,0]
+
+        # The deflection of the fiber(s) from previous results with these parameter choices
+        x0_test = -0.004765810967995735
+        x1_test = 1.0048647877439878
+
+        rel_error_0 = abs(1 - x0/x0_test)
+        rel_error_1 = abs(1 - x1/x1_test)
+        rel_error = np.sqrt(np.power(rel_error_0, 2) + np.power(rel_error_1, 2))
+
+        print(f"x0: {x0}")
+        print(f"x1: {x1}")
+        print(f"relative error x0 (driver):   {rel_error_0}")
+        print(f"relative error x1 (response): {rel_error_1}")
+        print(f"relative error: {rel_error}")
+
+        return rel_error
+
+
+def test_gen_config(sim_path):
+    assert gen_config(sim_path)
+
+def test_run_sim(sim_path):
+    assert run_sim(sim_path)
+
+def test_deflection(sim_path):
+    assert deflection(sim_path) < 1E-6


### PR DESCRIPTION
Starting the fiber refactor for different fiber types. Fixed the offset bug in FiberContainer::matvec that caused strange behavior where the velocities of the first fiber overwrote all of the other fibers up to some strange offset.